### PR TITLE
Fixed Compatibility issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The keys above are not valid, so don't try to use them.
 #### 1. Clone the repository
 
 ```
-git clone https://github.com/pzinsta/pizzeria.git
+git clone https://github.com/omarkashour/QAProject
 ```
 
 #### 2. Build the .war file

--- a/README.md
+++ b/README.md
@@ -115,16 +115,10 @@ We have two options here.
 If you've set the properties as environment variables, you can run the following command to start the app:
 
 ```
-java -jar webapp/target/dependency/webapp-runner.jar --port 8081 --path pizzeria webapp/target/*.war
-```
-
-##### Option 2. Pass the properties as JVM arguments
-
-In this case the command is going to be a bit more complicated.
+ java --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED -jar webapp/target/dependency/webapp-runner.jar --port 8081 --path pizzeria webapp/target/*.war
 
 ```
-java -Dbraintree.merchantId=<your Braintree merchant ID> -Dbraintree.publicKey=<your Braintree public key> -Dbraintree.privateKey=<your Braintree private key> -Drecaptcha.private.key=<your reCAPTCHA private key> -Drecaptcha.public.key=<your reCAPTCHA public key> -jar webapp/target/dependency/webapp-runner.jar --port 8081 --path pizzeria webapp/target/*.war
-```
+
 
 You can modify the port and the context path. Also, there are other [options](https://github.com/jsimone/webapp-runner#options) available.
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ If you've set the properties as environment variables, you can run the following
 
 ```
  java --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED -jar webapp/target/dependency/webapp-runner.jar --port 8081 --path pizzeria webapp/target/*.war
-
 ```
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <hibernate-validator.version>6.0.7.Final</hibernate-validator.version>
         <log4j.version>2.9.1</log4j.version>
         <junit.version>4.12</junit.version>
-        <mockito.version>2.10.0</mockito.version>
+        <mockito.version>5.14.2</mockito.version>
         <postgres.version>42.1.4</postgres.version>
         <apache.commons-lang.version>3.6</apache.commons-lang.version>
         <apache.commons-collections.version>4.1</apache.commons-collections.version>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -26,6 +26,28 @@
             <version>0.0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.3.1</version>
+        </dependency>
+        <dependency> <groupId>jakarta.xml.bind</groupId> <artifactId>jakarta.xml.bind-api</artifactId> <version>2.3.3</version> </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1.1</version>
+        </dependency>
+
+        <dependency>
             <groupId>pzinsta</groupId>
             <artifactId>dao-impl</artifactId>
             <version>0.0.1-SNAPSHOT</version>


### PR DESCRIPTION
Fixed Mockito Version: Resolved the issue "Mockito can only mock non-private & non-final classes" by upgrading the Mockito dependency to a newer version that supports mocking final classes.

Fixed javax.xml.bind Missing for Java 9+: Added the necessary dependencies for javax.xml.bind, which is missing in Java 9 and higher versions.